### PR TITLE
fix(changelog) make changelog checking more flexible

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -34,7 +34,7 @@ end
 desc 'Check Changelog.'
 task :check_changelog do
   v = Blacksmith::Modulefile.new.version
-  if File.readlines('CHANGELOG.md').grep(/Releasing #{v}/).size == 0
+  if File.readlines('CHANGELOG.md').grep(/#.+[Rr]eleas.+ #{v}/).size == 0
     fail "Unable to find a CHANGELOG.md entry for the #{v} release."
   end
 end


### PR DESCRIPTION
many of our repositories have a slightly different style of writing
changelog entires, so let's make it easier to match, with the power of
REGEX: in order to ensure this is what we're really looking for, we
check that it's a markdown header (at least one #)