### PR TITLE
dont expect whitespace before release number

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -34,7 +34,7 @@ end
 desc 'Check Changelog.'
 task :check_changelog do
   v = Blacksmith::Modulefile.new.version
-  if File.readlines('CHANGELOG.md').grep(/#.+[Rr]eleas.+ #{v}/).size == 0
+  if File.readlines('CHANGELOG.md').grep(/#.+[Rr]eleas.+#{v}/).size == 0
     fail "Unable to find a CHANGELOG.md entry for the #{v} release."
   end
 end

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -34,7 +34,7 @@ end
 desc 'Check Changelog.'
 task :check_changelog do
   v = Blacksmith::Modulefile.new.version
-  if File.readlines('CHANGELOG.md').grep(/#.+[Rr]eleas.+#{v}/).size == 0
+  if File.readlines('CHANGELOG.md').grep(/#.+[Rr]eleas.+#{Regexp.escape(v)}/).size == 0
     fail "Unable to find a CHANGELOG.md entry for the #{v} release."
   end
 end


### PR DESCRIPTION
the old regex failed if the number was surrounded by a link, like here:
https://raw.githubusercontent.com/voxpupuli/puppet-nginx/master/CHANGELOG.md

This got tested in our 0.4.0 release for nginx