### PR TITLE
Release candidate 0.4.0-rc0

### DIFF
--- a/lib/voxpupuli/release/version.rb
+++ b/lib/voxpupuli/release/version.rb
@@ -1,5 +1,5 @@
 module Voxpupuli
   module Release
-    VERSION = '0.3.0'
+    VERSION = '0.4.0-rc0'
   end
 end


### PR DESCRIPTION
Bump the version so that it's clear it's active on HEAD, not a tagged version.