### PR TITLE
Proper pre-release version string

### DIFF
--- a/lib/voxpupuli/release/version.rb
+++ b/lib/voxpupuli/release/version.rb
@@ -1,5 +1,5 @@
 module Voxpupuli
   module Release
-    VERSION = '0.4.0-rc0'
+    VERSION = '0.4.0.pre'
   end
 end


### PR DESCRIPTION
`0.4.0-rc0` generated a `malformed version string` error in bundler. Using `0.4.0.pre` per the documentation as http://guides.rubygems.org/specification-reference/#version