### PR TITLE
set a message pattern for new releases

### DIFF
--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -6,6 +6,7 @@ task "travis_release" do
   Blacksmith::RakeTask.new do |t|
     t.build = false # do not build the module nor push it to the Forge
     t.tag_sign = true # sign release with gpg
+    t.tag_message_pattern = "Version %s" # required tag message for gpg-signed tags
     # just do the tagging [:clean, :tag, :bump_commit]
   end
 


### PR DESCRIPTION
We sign git tags with gpg. A message is required for gpg signed tags.