### PR TITLE
directly load blacksmitch rake tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gemspec
+
+group :release do
+  gem 'github_changelog_generator', '>= 1.16.1',  :require => false
+end

--- a/lib/voxpupuli/release/rake_tasks.rb
+++ b/lib/voxpupuli/release/rake_tasks.rb
@@ -1,8 +1,8 @@
+require 'puppet_blacksmith/rake_tasks'
 
 desc 'release new version through Travis-ci'
 task "travis_release" do
 
-  require 'puppet_blacksmith/rake_tasks'
   Blacksmith::RakeTask.new do |t|
     t.build = false # do not build the module nor push it to the Forge
     t.tag_sign = true # sign release with gpg

--- a/voxpupuli-release.gemspec
+++ b/voxpupuli-release.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |s|
   # Runtime dependencies, but also probably dependencies of requiring projects
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'puppet-blacksmith', '>= 4.0.0'
-  s.add_development_dependency 'github_changelog_generator'
 end


### PR DESCRIPTION
puppet_blacksmith is already a dependency. We can directly load the
provided rake tasks so other libs, that depend on voxpupuli-release
don't need to load blacksmith as well.